### PR TITLE
[FIX] Link for Implementation Methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 ## Books
 - Free Books
-    - [Implementation Methodology](https://drive.google.com/file/d/1qgFdEtotMjImuoIZ1AHv3XdEoZMkOQl9/view) - Official book for implementation
+    - [Implementation Methodology](https://www.odoo.com/web/content/31019907) - Official book for implementation
     - [Odoo Accounting V15](https://www.cybrosys.com/odoo/odoo-books/complete-finance-management-with-odoo-accounting/) - Functional Documentation for Accounting v15 by Cybrosys Technologies.
     - [Odoo Book V15 Enterprise](https://www.cybrosys.com/odoo/odoo-books/odoo-book-v15/) - Complete Functional Documentation for v15 Enterprise by Cybrosys Technologies.
     - [Odoo Book V15 Community](https://www.cybrosys.com/odoo/odoo-books/community-edition-v15/) - Complete Functional Documentation for v15 Community by Cybrosys Technologies.


### PR DESCRIPTION
Updated link points to www.odoo.com where the latest copy will always be

Prior link pointed to an outdated version.