### PR TITLE
Added odoo-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 - All-in-one tools
     - [Doodba](https://github.com/tecnativa/doodba) - Base (docker) image for making the creation of customized Odoo environments a piece of cake.
+    - [odoo-tools](https://github.com/llacroix/odoo-tools) - Generic tool/library to make management of odoo environment management easier.
 - Search Engine
     - [Odoo Code Search](http://www.odoo-code-search.com/). A searchable index of odoo source code.
 - Script


### PR DESCRIPTION
Odoo tools is a python library that originated from my fork of docker image and internal CI tools at work. Eventually, things got merged into this library and recently I made an important refactor that makes it possible to use a lot more as a library than in the past. 

One thing is that you can use this library in an "infrastructure as code" setup. There's an API that can let you integrate it in let say salt/ansible. Installing odoo is as simple as:

    env.manage.install_odoo('15.0', repo="https://github.com/odoo/odoo.git") # install from git
    env.manage.install_odoo('15.0', release="20220701") # install from nightly.odoo.com

In other words, it's library that can be used as foundation to build more CI tools or it can be used as is... One example is the ability to search for modules that are installed in your environment.

Let say you have a dev environment and you have some modules in folder A, folder B etc..

    odootools path add addons/folder_a
    odootools path add addons/folder_b
    odootools modules requirements # show python requirements

But since the library is able to introspect folders you can simply write the example above as such:

    odootools path add addons
    odootools modules requirements # show python requirements

folder_b and folder_a will be added to the addons_path of the default odoorc file it can find. 

It can also be used as a library that will help you do maintenance tasks like installing modules/uninstalling modules and initializing a new database.